### PR TITLE
fix: skip active venv Python when detecting system interpreter

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -431,6 +431,14 @@ find_python() {
     for bin in "${candidates[@]}"; do
         local resolved
         resolved="$(command -v "$bin" 2>/dev/null || true)"
+        # Skip any Python that lives inside the currently-active virtual
+        # environment.  Using a venv's interpreter to bootstrap a new venv
+        # can fail on systems where the venv Python lacks ensurepip (e.g.
+        # Debian/Ubuntu python3-venv not installed into the venv), and can
+        # produce a broken "nested venv" on other systems.
+        if [[ -n "${VIRTUAL_ENV:-}" && "$resolved" == "${VIRTUAL_ENV}"/* ]]; then
+            continue
+        fi
         if [[ -n "$resolved" ]] && python_version_ok "$resolved"; then
             PYTHON_BIN="$resolved"
             return 0

--- a/install_win.ps1
+++ b/install_win.ps1
@@ -139,7 +139,14 @@ function Test-PythonVersion {
 $candidates = @("python", "python3", "python3.13", "python3.12", "python3.11")
 foreach ($c in $candidates) {
     $resolved = Get-Command $c -ErrorAction SilentlyContinue
-    if ($resolved -and (Test-PythonVersion $resolved.Source)) {
+    if (-not $resolved) { continue }
+    # Skip any Python that lives inside the currently-active virtual environment.
+    # Using a venv's interpreter to bootstrap a new venv can produce a broken
+    # "nested venv" and may fail if ensurepip is unavailable inside the venv.
+    if ($env:VIRTUAL_ENV -and $resolved.Source.StartsWith($env:VIRTUAL_ENV, [System.StringComparison]::OrdinalIgnoreCase)) {
+        continue
+    }
+    if (Test-PythonVersion $resolved.Source) {
         $PythonBin = $resolved.Source
         break
     }


### PR DESCRIPTION
When a user runs the installer with a virtual environment named "venv" already activated, `find_python` resolves `python3` to the venv's interpreter via PATH.  Using a venv's Python to bootstrap a new venv creates a broken "nested venv" and fails on Debian/Ubuntu where the venv interpreter lacks ensurepip.

Both install.sh and install_win.ps1 now skip any Python binary whose path starts with $VIRTUAL_ENV, falling through to absolute system paths (/usr/bin/python3, /opt/homebrew/bin/python3, etc.).