### PR TITLE
feat: add Novita AI to onboarding wizard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 # "openrouter"   — shortcut for OpenRouter (set OPENAI_COMPAT_API_KEY=sk-or-...)
 # "local"        — shortcut for local vLLM at http://localhost:8000/v1
 # "minimax"      — shortcut for Minimax (set MINIMAX_API_KEY=...)
+# "novita"       — shortcut for Novita AI (200+ models, set NOVITA_API_KEY=...)
 # "codex"        — shortcut for OpenAI Codex (browser OAuth or OPENAI_COMPAT_API_KEY)
 LLM_BACKEND=anthropic
 
@@ -64,6 +65,13 @@ CODEX_MODEL=o4-mini
 # Available models: MiniMax-Text-01, abab6.5s-chat
 MINIMAX_API_KEY=
 MINIMAX_MODEL=MiniMax-Text-01
+
+# ── Novita AI ────────────────────────────────────────────────────────────────
+# Used when LLM_BACKEND=novita.
+# OpenAI-compatible API with 200+ models. Get your key at https://novita.ai
+# Default model: moonshotai/kimi-k2.5 (262k context, function calling, vision)
+NOVITA_API_KEY=
+NOVITA_MODEL=moonshotai/kimi-k2.5
 
 # Search APIs (optional — web search degrades gracefully without these)
 BRAVE_SEARCH_API_KEY=

--- a/eurekaclaw/onboard.py
+++ b/eurekaclaw/onboard.py
@@ -193,10 +193,11 @@ def run_onboard(non_interactive: bool, reset: bool, env_file: str) -> None:
         "  [dim]openai_compat[/dim] — Any OpenAI-compatible endpoint\n"
         "  [dim]local[/dim]         — Local vLLM / LM Studio at localhost:8000\n"
         "  [dim]minimax[/dim]       — Minimax\n"
+        "  [dim]novita[/dim]        — Novita AI (200+ models, OpenAI-compatible)\n"
     )
     backend = ask_choice(
         "LLM_BACKEND",
-        ["anthropic", "oauth", "codex", "openrouter", "openai_compat", "local", "minimax"],
+        ["anthropic", "oauth", "codex", "openrouter", "openai_compat", "local", "minimax", "novita"],
         get("LLM_BACKEND", "anthropic"),
     )
     cfg["LLM_BACKEND"] = backend
@@ -278,6 +279,17 @@ def run_onboard(non_interactive: bool, reset: bool, env_file: str) -> None:
         )
         cfg["MINIMAX_MODEL"] = ask(
             "  MINIMAX_MODEL", get("MINIMAX_MODEL", "MiniMax-Text-01")
+        )
+        cfg["ANTHROPIC_AUTH_MODE"] = get("ANTHROPIC_AUTH_MODE", "api_key")
+        cfg["CCPROXY_PORT"] = get("CCPROXY_PORT", "8765")
+        cfg["ANTHROPIC_BASE_URL"] = get("ANTHROPIC_BASE_URL", "")
+
+    elif backend == "novita":
+        cfg["NOVITA_API_KEY"] = ask(
+            "  NOVITA_API_KEY", get("NOVITA_API_KEY", ""), secret=True
+        )
+        cfg["NOVITA_MODEL"] = ask(
+            "  NOVITA_MODEL", get("NOVITA_MODEL", "moonshotai/kimi-k2.5")
         )
         cfg["ANTHROPIC_AUTH_MODE"] = get("ANTHROPIC_AUTH_MODE", "api_key")
         cfg["CCPROXY_PORT"] = get("CCPROXY_PORT", "8765")


### PR DESCRIPTION
## Summary

Follow-up to #39 — the Novita AI backend was added to the runtime (config, factory, adapter) but not to the onboarding wizard. Users running `eurekaclaw onboard` couldn't see or select Novita as an LLM backend option.

- Add `novita` to the `LLM_BACKEND` choice list and description in `onboard.py`
- Add `elif backend == "novita"` branch prompting for `NOVITA_API_KEY` and `NOVITA_MODEL`
- Add Novita section to `.env.example` with documentation and defaults

## Test plan

- [x] Run `eurekaclaw onboard` and verify "novita" appears in the backend selector
- [ ] Select novita → confirm it prompts for API key and model
- [ ] Verify generated `.env` contains `NOVITA_API_KEY` and `NOVITA_MODEL`
- [ ] Verify `eurekaclaw onboard --non-interactive` still works with default values
