### PR TITLE
writer: protect math regions in _clean_proof_text markdown→LaTeX pass

### DIFF
--- a/eurekaclaw/agents/writer/agent.py
+++ b/eurekaclaw/agents/writer/agent.py
@@ -703,8 +703,46 @@ If a section has little content, write at least two sentences rather than omitti
         pt = re.sub(r"(?m)^\s*[-*]\s+", "\n\n", pt)
 
         # ── Step 5: convert remaining **bold** / *italic* ─────────────────────
+        # Protect math regions first — otherwise asterisks used as multiplication
+        # or convolution (e.g. `\(\mu*\nu\)`) get paired across spans and turned
+        # into `\textit{...}`, producing malformed LaTeX that crashes pdflatex.
+        _math_saved: list[str] = []
+
+        def _save_math(m: "re.Match[str]") -> str:
+            _math_saved.append(m.group(0))
+            return f"\x00MATH{len(_math_saved) - 1}\x00"
+
+        _MATH_ENVS = (
+            "equation", "align", "gather", "multline",
+            "eqnarray", "flalign", "alignat", "displaymath", "math",
+        )
+        _env_alt = "|".join(_MATH_ENVS)
+        for _pat in (
+            # \begin{env}...\end{env}, starred or not — must come before \[…\]
+            # since these environments can contain \[ internally? No, but
+            # ordering by specificity first is still safer.
+            rf"\\begin\{{(?:{_env_alt})\*?\}}.*?\\end\{{(?:{_env_alt})\*?\}}",
+            r"\\\[.*?\\\]",                    # display \[ ... \]
+            r"\\\(.*?\\\)",                    # inline  \( ... \)
+            # Display $$...$$ — opening $$ must not be preceded by a backslash
+            # (so `\$\$` stays as two literal dollar signs).
+            r"(?<!\\)\$\$(?:\\.|[^$])*?(?<!\\)\$\$",
+            # Inline $...$ — same backslash guard on both ends, disallow
+            # a second $ adjacent to either delimiter, and require the
+            # opening $ to be followed by a non-digit/non-space so prose
+            # dollar amounts like `$5` do not pair across prose (which
+            # would engulf any `*italic*` sitting between them).
+            r"(?<!\\)(?<!\$)\$(?!\$)(?![\s\d])(?:\\.|[^\n$])+?(?<!\\)(?<!\$)\$(?!\$)",
+        ):
+            pt = re.sub(_pat, _save_math, pt, flags=re.DOTALL)
+
         pt = re.sub(r"\*\*([^*\n]+)\*\*", r"\\textit{\1}", pt)
         pt = re.sub(r"\*([^*\n]+)\*",     r"\\textit{\1}", pt)
+
+        if _math_saved:
+            def _restore_math(m: "re.Match[str]") -> str:
+                return _math_saved[int(m.group(1))]
+            pt = re.sub(r"\x00MATH(\d+)\x00", _restore_math, pt)
 
         # ── Step 6: "Cited from: <arxiv_id>." → \cite{key} ───────────────────
         def _cited_repl(m: re.Match) -> str:  # type: ignore[type-arg]

--- a/tests/unit/test_clean_proof_text.py
+++ b/tests/unit/test_clean_proof_text.py
@@ -1,0 +1,163 @@
+"""Unit tests for WriterAgent._clean_proof_text markdown-to-LaTeX conversion.
+
+Regression: asterisks inside math expressions (e.g. convolution `\\mu*\\nu`)
+must not be interpreted as markdown italic delimiters, because that corrupts
+the LaTeX output and causes pdflatex to fail with "Missing $ inserted".
+"""
+
+from eurekaclaw.agents.writer.agent import WriterAgent
+
+
+def test_preserves_asterisk_inside_inline_math():
+    """`\\(\\mu*\\nu\\)` must not become `\\(\\mu\\textit{\\nu\\)`."""
+    raw = (
+        "The convolution \\(\\mu*\\nu\\) is the law of "
+        "\\(X+Y \\pmod 1\\) when independent.\n"
+    )
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\mu*\\nu" in out
+    assert "\\textit{" not in out
+
+
+def test_preserves_multiple_asterisks_across_math_spans():
+    """Multiple math spans containing `*` must all survive intact."""
+    raw = (
+        "This yields \\(\\mu*\\nu=\\mu\\). "
+        "Symmetry gives \\(\\nu*\\mu=\\mu\\), "
+        "and taking \\(\\nu=\\mu\\) gives \\(\\mu*\\mu=\\mu\\).\n"
+    )
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\mu*\\nu=\\mu" in out
+    assert "\\nu*\\mu=\\mu" in out
+    assert "\\mu*\\mu=\\mu" in out
+    assert "\\textit{" not in out
+
+
+def test_preserves_asterisk_inside_display_math():
+    """`\\[...*...\\]` must not be mangled."""
+    raw = "We have\n\\[\n\\mu*\\nu=\\mu.\n\\]\nDone.\n"
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\mu*\\nu=\\mu" in out
+    assert "\\textit{" not in out
+
+
+def test_still_converts_markdown_italic_in_prose():
+    """Regression guard: legitimate *italic* prose must still convert."""
+    raw = "Thus *this phrase* is emphasized.\n"
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\textit{this phrase}" in out
+
+
+def test_still_converts_markdown_bold_in_prose():
+    """Regression guard: legitimate **bold** prose must still convert."""
+    raw = "Thus **this phrase** is emphasized.\n"
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\textit{this phrase}" in out
+
+
+def test_mixed_math_and_italic_prose():
+    """Math asterisks preserved; prose italics converted; both in same input."""
+    raw = (
+        "Informally, *the key idea* is that \\(\\mu*\\nu=\\mu\\).\n"
+    )
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\textit{the key idea}" in out
+    assert "\\mu*\\nu=\\mu" in out
+
+
+def test_preserves_asterisk_inside_align_environment():
+    """`align`/`align*` blocks must be protected just like `\\[...\\]`."""
+    raw = (
+        "We compute\n"
+        "\\begin{align}\n"
+        "\\mu*\\nu &= \\mu \\\\\n"
+        "\\nu*\\mu &= \\mu.\n"
+        "\\end{align}\n"
+        "Done.\n"
+    )
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\mu*\\nu" in out
+    assert "\\nu*\\mu" in out
+    assert "\\textit{" not in out
+
+
+def test_preserves_asterisk_inside_align_star_environment():
+    """Starred math environments (no numbering) are common in proofs."""
+    raw = (
+        "\\begin{align*}\n"
+        "\\mu*\\nu=\\mu, \\qquad \\nu*\\mu=\\mu.\n"
+        "\\end{align*}\n"
+    )
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\mu*\\nu=\\mu" in out
+    assert "\\nu*\\mu=\\mu" in out
+    assert "\\textit{" not in out
+
+
+def test_preserves_asterisk_inside_equation_environment():
+    """`equation`/`equation*` blocks must be protected."""
+    raw = (
+        "\\begin{equation}\n"
+        "\\mu*\\nu = \\mu.\n"
+        "\\end{equation}\n"
+    )
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\mu*\\nu = \\mu" in out
+    assert "\\textit{" not in out
+
+
+def test_escaped_dollar_is_not_treated_as_math_delimiter():
+    """`\\$` is a literal dollar sign in text, not a math delimiter.
+
+    If `\\$` were mistaken for the start of a math region, surrounding
+    `*italic*` would be masked inside that fake region and never converted.
+    """
+    raw = "The cost is \\$5 per *item*, while \\$10 covers *two*.\n"
+    out = WriterAgent._clean_proof_text(raw)
+    # Escaped dollars must be preserved verbatim.
+    assert "\\$5" in out
+    assert "\\$10" in out
+    # Prose italics outside math must still convert.
+    assert "\\textit{item}" in out
+    assert "\\textit{two}" in out
+
+
+def test_unescaped_dollar_prices_do_not_engulf_italic_between_them():
+    """Bare `$5 ... *italic* ... $10` must not pair into a fake math region.
+
+    If the two prose dollars are treated as math delimiters, `*italic*` sits
+    inside the fake region, never gets converted, and the output still
+    contains literal markdown.
+    """
+    raw = "The bounty is $5 for *one* and $10 for *two*.\n"
+    out = WriterAgent._clean_proof_text(raw)
+    assert "$5" in out
+    assert "$10" in out
+    assert "\\textit{one}" in out
+    assert "\\textit{two}" in out
+
+
+def test_escaped_double_dollar_is_not_treated_as_display_math():
+    """`\\$\\$...\\$\\$` is two literal dollars, not a display-math block."""
+    raw = "Prices \\$\\$ and more \\$\\$, with *emphasis* between.\n"
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\$\\$" in out
+    assert "\\textit{emphasis}" in out
+
+
+def test_preserves_asterisk_inside_gather_and_multline():
+    """Less common but still valid display-math environments."""
+    raw = (
+        "\\begin{gather}\n"
+        "\\mu*\\nu=\\mu \\\\\n"
+        "\\nu*\\mu=\\mu\n"
+        "\\end{gather}\n"
+        "\\begin{multline*}\n"
+        "\\mu*\\nu*\\rho=\\mu.\n"
+        "\\end{multline*}\n"
+    )
+    out = WriterAgent._clean_proof_text(raw)
+    assert "\\mu*\\nu=\\mu" in out
+    assert "\\nu*\\mu=\\mu" in out
+    assert "\\mu*\\nu*\\rho=\\mu" in out
+    assert "\\textit{" not in out


### PR DESCRIPTION
Asterisks inside math (e.g. convolution `\mu*\nu`) were being paired by the markdown `*italic*` regex across math spans, corrupting the LaTeX into unbalanced `\textit{...}` and crashing pdflatex with "Missing $ inserted" at `\end{proof}`.

Mask math regions (`\(...\)`, `\[...\]`, `$...$`, `$$...$$`, and the common math environments) with placeholders before the bold/italic substitution, then restore. Escaped `\$` and prose dollar amounts like `$5` are not treated as math delimiters.